### PR TITLE
Fix OutOfMemory Issue

### DIFF
--- a/aws-codegurureviewer-repositoryassociation/src/main/java/software/amazon/codegurureviewer/repositoryassociation/CodeGuruReviewerClientBuilder.java
+++ b/aws-codegurureviewer-repositoryassociation/src/main/java/software/amazon/codegurureviewer/repositoryassociation/CodeGuruReviewerClientBuilder.java
@@ -91,25 +91,21 @@ public class CodeGuruReviewerClientBuilder {
                         c.exception().getCause().getClass().equals(AbortedException.class);
     }
 
-    static ClientOverrideConfiguration getClientConfiguration() {
-        return ClientOverrideConfiguration.builder()
+    static ClientOverrideConfiguration clientConfiguration = ClientOverrideConfiguration.builder()
                 .retryPolicy(getRetryPolicy())
                 .apiCallTimeout(OVERALL_TIMEOUT)
                 .apiCallAttemptTimeout(ATTEMPT_TIMEOUT)
                 .build();
-    }
 
-    private static SdkHttpClient getHttpClient() {
-        return ApacheHttpClient.builder()
-                .connectionTimeout(CONNECTION_TIMEOUT)
-                .socketTimeout(SOCKET_TIMEOUT)
-                .build();
-    }
+    private static SdkHttpClient httpClient = ApacheHttpClient.builder()
+            .connectionTimeout(CONNECTION_TIMEOUT)
+            .socketTimeout(SOCKET_TIMEOUT)
+            .build();
 
     public static CodeGuruReviewerClient getClient() {
         return CodeGuruReviewerClient.builder()
-                .overrideConfiguration(getClientConfiguration())
-                .httpClient(getHttpClient())
+                .overrideConfiguration(clientConfiguration)
+                .httpClient(httpClient)
                 .build();
     }
 }

--- a/aws-codegurureviewer-repositoryassociation/src/test/java/software/amazon/codegurureviewer/repositoryassociation/CodeGuruReviewerClientConfigurationTest.java
+++ b/aws-codegurureviewer-repositoryassociation/src/test/java/software/amazon/codegurureviewer/repositoryassociation/CodeGuruReviewerClientConfigurationTest.java
@@ -47,7 +47,7 @@ public class CodeGuruReviewerClientConfigurationTest {
     }
 
     private ClientOverrideConfiguration getClientConfiguration() {
-        return CodeGuruReviewerClientBuilder.getClientConfiguration();
+        return CodeGuruReviewerClientBuilder.clientConfiguration;
     }
 
     private RetryPolicyContext createRetryContext(SdkException exception) {


### PR DESCRIPTION
*Description of changes:*

- Handler creates new HttpClient ever request which is costly and can cause handler lambda to run out of memory. By making the HttpClient static, we avoid this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
