### PR TITLE
Chore fix out of memory

### DIFF
--- a/aws-codegurureviewer-repositoryassociation/pom.xml
+++ b/aws-codegurureviewer-repositoryassociation/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.1</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-codegurureviewer-repositoryassociation/src/main/java/software/amazon/codegurureviewer/repositoryassociation/BaseHandlerStd.java
+++ b/aws-codegurureviewer-repositoryassociation/src/main/java/software/amazon/codegurureviewer/repositoryassociation/BaseHandlerStd.java
@@ -1,6 +1,5 @@
 package software.amazon.codegurureviewer.repositoryassociation;
 
-import lombok.Setter;
 import software.amazon.awssdk.awscore.AwsRequest;
 import software.amazon.awssdk.awscore.AwsResponse;
 import software.amazon.awssdk.services.codegurureviewer.CodeGuruReviewerClient;
@@ -12,7 +11,6 @@ import software.amazon.awssdk.services.codegurureviewer.model.NotFoundException;
 import software.amazon.awssdk.services.codegurureviewer.model.ThrottlingException;
 import software.amazon.awssdk.services.codegurureviewer.model.ValidationException;
 import software.amazon.cloudformation.exceptions.CfnAccessDeniedException;
-import software.amazon.cloudformation.exceptions.CfnInternalFailureException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
@@ -30,28 +28,7 @@ import java.time.Duration;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
-    // Allow current Lambda Handler runner to call stabilizeOnHandle this many times
-    private final static int MAX_STABILIZE_ATTEMPTS = 5;
-    // Wait time in between each stabilizeOnHandle call. Average time for repository association is around 25 seconds
-    // and the Lambda handler timeout time is 1 min so ideally the MAX_STABILIZED_ATTEMPS * STABILIZE_SLEEP_TIME_MS
-    // should be between 25,000 - 60,000 ms (25 - 60 seconds). In case the Lambda times out, stabilization will be
-    // called again in the new Lambda call.
-    private final static Duration STABILIZE_SLEEP_TIME_MS = Duration.ofMillis(7000);
-
-    private final int maxStabilizeAttempts;
-    private final Duration stabilizeSleepTimeMs;
-
     protected static final Constant BACKOFF_STRATEGY = Constant.of().timeout(Duration.ofMinutes(5L)).delay(Duration.ofSeconds(10L)).build();
-
-    public BaseHandlerStd() {
-        this.maxStabilizeAttempts = MAX_STABILIZE_ATTEMPTS;
-        this.stabilizeSleepTimeMs = STABILIZE_SLEEP_TIME_MS;
-    }
-
-    public BaseHandlerStd(final int maxStabilizeAttempts, final Duration stabilizeSleepTimeMs) {
-        this.maxStabilizeAttempts = maxStabilizeAttempts;
-        this.stabilizeSleepTimeMs = stabilizeSleepTimeMs;
-    }
 
     @Override
     public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(
@@ -107,29 +84,4 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final CallbackContext callbackContext) {
         return true;
     };
-
-    protected boolean stabilizeLoop(
-            final AwsRequest awsRequest,
-            final AwsResponse awsResponse,
-            final ProxyClient<CodeGuruReviewerClient> proxyClient,
-            final ResourceModel model,
-            final CallbackContext callbackContext
-    ) {
-        boolean stabilized = false;
-        int stabilizeAttempts = 0;
-
-        while (!stabilized && stabilizeAttempts < maxStabilizeAttempts) {
-            stabilized = stabilizeOnHandle(awsRequest, awsResponse, proxyClient, model, callbackContext);
-
-            try {
-                Thread.sleep(stabilizeSleepTimeMs.toMillis());
-            } catch (InterruptedException e) {
-                throw new CfnInternalFailureException(e);
-            }
-
-            stabilizeAttempts += 1;
-        }
-
-        return stabilized;
-    }
 }

--- a/aws-codegurureviewer-repositoryassociation/src/main/java/software/amazon/codegurureviewer/repositoryassociation/CreateHandler.java
+++ b/aws-codegurureviewer-repositoryassociation/src/main/java/software/amazon/codegurureviewer/repositoryassociation/CreateHandler.java
@@ -25,19 +25,9 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-import java.time.Duration;
-
 public class CreateHandler extends BaseHandlerStd {
 
     private Logger logger;
-
-    public CreateHandler() {
-        super();
-    }
-
-    public CreateHandler(final int maxStabilizedAttempts, final Duration stabilizeSleepTimeMs) {
-        super(maxStabilizedAttempts, stabilizeSleepTimeMs);
-    }
 
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(

--- a/aws-codegurureviewer-repositoryassociation/src/main/java/software/amazon/codegurureviewer/repositoryassociation/DeleteHandler.java
+++ b/aws-codegurureviewer-repositoryassociation/src/main/java/software/amazon/codegurureviewer/repositoryassociation/DeleteHandler.java
@@ -24,18 +24,8 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-import java.time.Duration;
-
 public class DeleteHandler extends BaseHandlerStd {
     private Logger logger;
-
-    public DeleteHandler() {
-        super();
-    }
-
-    public DeleteHandler(final int maxStabilizedAttempts, final Duration stabilizeSleepTimeMs) {
-        super(maxStabilizedAttempts, stabilizeSleepTimeMs);
-    }
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
@@ -54,9 +44,10 @@ public class DeleteHandler extends BaseHandlerStd {
                         proxy.initiate("AWS-CodeGuruReviewer-RepositoryAssociation::Delete", proxyClient, model,
                                 callbackContext)
                                 .translateToServiceRequest(Translator::translateToDisassociateRepositoryRequest)
+                                .backoffDelay(BACKOFF_STRATEGY)
                                 .makeServiceCall((awsRequest, sdkProxyClient) -> deleteResource(awsRequest,
                                         sdkProxyClient, model, callbackContext))
-                                .stabilize(this::stabilizeLoop)
+                                .stabilize(this::stabilizeOnHandle)
                                 .success());
     }
 

--- a/aws-codegurureviewer-repositoryassociation/src/test/java/software/amazon/codegurureviewer/repositoryassociation/CreateHandlerTest.java
+++ b/aws-codegurureviewer-repositoryassociation/src/test/java/software/amazon/codegurureviewer/repositoryassociation/CreateHandlerTest.java
@@ -37,8 +37,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -57,7 +55,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
     @BeforeEach
     public void setup() {
-        handler = new CreateHandler(TEST_MAX_STABILIZE_ATTEMPTS, TEST_STABILIZE_SLEEP_TIME_MS);
+        handler = new CreateHandler();
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
         sdkClient = mock(CodeGuruReviewerClient.class);
         proxyClient = MOCK_PROXY(proxy, sdkClient);


### PR DESCRIPTION
*Description of changes:*

- Fix out of memory issue by allowing the framework to call the stabilization method
- Use backOffDelay which requires upgrade to RPDK v2.0.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
