### PR TITLE
Increase Lambda memory to address unable to create native thread issue

### DIFF
--- a/aws-codegurureviewer-repositoryassociation/README.md
+++ b/aws-codegurureviewer-repositoryassociation/README.md
@@ -5,7 +5,7 @@ Congratulations on starting development! Next steps:
 1. Write the JSON schema describing your resource, `aws-codegurureviewer-repositoryassociation.json`
 1. Implement your resource handlers.
 
-The RPDK will automatically generate the correct resource model from the schema whenever the project is built via Maven. You can also do this manually with the following command: `cfn generate`.
+The RPDK will automatically generate the correct resource model from the schema whenever the project is built via Maven. You can also do this manually with the following command: `cfn generate`. This requires installation of Cloudformation CLI plugin (e.g `python3 -m pip install cloudformation-cli-java-plugin==2.0.1`)
 
 > Please don't modify files under `target/generated-sources/rpdk`, as they will be automatically overwritten.
 

--- a/aws-codegurureviewer-repositoryassociation/docs/README.md
+++ b/aws-codegurureviewer-repositoryassociation/docs/README.md
@@ -47,7 +47,7 @@ _Maximum_: <code>100</code>
 
 _Pattern_: <code>^\S[\w.-]*$</code>
 
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### Type
 
@@ -59,7 +59,7 @@ _Type_: String
 
 _Allowed Values_: <code>CodeCommit</code> | <code>Bitbucket</code> | <code>GitHubEnterpriseServer</code>
 
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### Owner
 
@@ -75,7 +75,7 @@ _Maximum_: <code>100</code>
 
 _Pattern_: <code>^\S(.*\S)?$</code>
 
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### ConnectionArn
 
@@ -89,7 +89,7 @@ _Maximum_: <code>256</code>
 
 _Pattern_: <code>arn:aws(-[\w]+)*:.+:.+:[0-9]{12}:.+</code>
 
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 ## Return Values
 
@@ -106,3 +106,4 @@ For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::G
 #### AssociationArn
 
 The Amazon Resource Name (ARN) of the repository association.
+

--- a/aws-codegurureviewer-repositoryassociation/pom.xml
+++ b/aws-codegurureviewer-repositoryassociation/pom.xml
@@ -72,7 +72,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.13.48</version>
+                <version>2.15.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/aws-codegurureviewer-repositoryassociation/template.yml
+++ b/aws-codegurureviewer-repositoryassociation/template.yml
@@ -12,6 +12,7 @@ Resources:
     Properties:
       Handler: software.amazon.codegurureviewer.repositoryassociation.HandlerWrapper::handleRequest
       Runtime: java8
+      MemorySize: 256
       CodeUri: ./target/aws-codegurureviewer-repositoryassociation-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
@@ -19,4 +20,5 @@ Resources:
     Properties:
       Handler: software.amazon.codegurureviewer.repositoryassociation.HandlerWrapper::testEntrypoint
       Runtime: java8
+      MemorySize: 256
       CodeUri: ./target/aws-codegurureviewer-repositoryassociation-handler-1.0-SNAPSHOT.jar


### PR DESCRIPTION
*Issue #, if available:*  Bugfix to increase lambda memory and upgrade to aws java sdk 2.15.0

*Description of changes:*
Currently we see unable to create native thread issue occassionally. Increasing the Lambda memory from 128 to 256 to address the same.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
